### PR TITLE
Fix syntax errors and undefined variables in pdf_packer.py

### DIFF
--- a/app/pdf_packer.py
+++ b/app/pdf_packer.py
@@ -78,16 +78,21 @@ class PDFComposer:
         packing_decisions: List[Dict] = []
 
         i = 0
-        while  << len(infos):
+        while i < len(infos):
             cells, used, allow_upscale, stretch = self._pack_page_advanced(infos[i:], margin)
             # draw page with cells
             page_meta = {"items": []}
             for info, (x, y, w, h) in cells:
-                # Always preserve aspect ratio to avoid distortion
-                scale = min(w / info.width, h / info.height) if allow_upscale else min(w / info.width, h / info.heightawImage(str(info.path), ox, oy, width=rw, height=rh, preserveAspectRatio=False, anchor='c')
+                if stretch:
+                    # fill the entire cell (allow distortion)
+                    ox, oy = x, y
+                    rw, rh = w, h
+                    c.drawImage(str(info.path), ox, oy, width=rw, height=rh, preserveAspectRatio=False, anchor='c')
                 else:
                     # scale to fit cell, preserve aspect
-                    scale = min(w / info.width, h / info.height) if allow_upscale else min(w / info.width, h / info.height, 1.0)
+                    scale = min(w / info.width, h / info.height)
+                    if not allow_upscale:
+                        scale = min(scale, 1.0)
                     rw, rh = int(info.width * scale), int(info.height * scale)
                     # center within cell
                     ox = int(x + (w - rw) // 2)


### PR DESCRIPTION
This pull request addresses multiple syntax errors and variable issues in the `pdf_packer.py` file. Specifically, the following changes have been made:

1. Corrected a syntax error in the `while` loop condition on line 81, ensuring a proper comparison.
2. Closed an unclosed parenthesis that was previously causing a parsing error.
3. Added necessary variable definitions for `ox`, `oy`, `rw`, and `rh` to prevent undefined variable errors.
4. Adjusted the drawing logic for images to accommodate these variables, ensuring the function can now correctly handle image dimensions and positions. 

These modifications help the application run without syntax warnings and ensure all variables are defined before use.

---

> This pull request was co-created with Cosine Genie

Original Task: [blank-project/gnpksj4v3lxr](https://cosine.sh/p0drixu2k2bx/blank-project/task/gnpksj4v3lxr)
Author: Janith Manodaya
