### PR TITLE
Fix image sending function to resolve video misclassification issue

### DIFF
--- a/app/green_api.py
+++ b/app/green_api.py
@@ -62,6 +62,23 @@ class GreenAPIClient:
             resp.raise_for_status()
             return resp.json()
 
+    async def send_image_by_url(self, chat_id: str, url_file: str, caption: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Use dedicated image endpoint so WhatsApp treats the media as an image,
+        avoiding misclassification as a video/document.
+        """
+        url = self._url("sendImageByUrl")
+        payload = {
+            "chatId": chat_id,
+            "urlFile": url_file,
+        }
+        if caption:
+            payload["caption"] = caption
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(url, json=payload)
+            resp.raise_for_status()
+            return resp.json()
+
     async def send_file_by_id(self, chat_id: str, file_id: str, filename: str, caption: Optional[str] = None) -> Dict[str, Any]:
         """
         Alternative to send by URL: some deployments prefer sending by previously uploaded file id.

--- a/app/main.py
+++ b/app/main.py
@@ -671,14 +671,13 @@ async def _search_verify_send_image(sender: str, query: str, prefer_ext: str, db
                     pass
                 continue
 
-            # Upload and send
+            # Upload and send (use dedicated image endpoint to avoid misclassification)
             up = await client.upload_file(out_proc)
             if _is_sender_allowed(sender, db):
                 cap = f"Image for: {query}"
-                await client.send_file_by_url(
+                await client.send_image_by_url(
                     chat_id=sender,
                     url_file=up.get("urlFile", ""),
-                    filename=out_proc.name,
                     caption=cap,
                 )
             try:


### PR DESCRIPTION
This pull request modifies the image search and send functionality to use a dedicated endpoint for sending images. The previous implementation was misclassifying images as video files, resulting in errors when trying to open them in WhatsApp. The new method, `send_image_by_url`, ensures that the media is treated as an image, preventing those issues. Additionally, the image upload in the `_reencode_supported` function is updated to call this new method instead of the generic `send_file_by_url` method.

---

> This pull request was co-created with Cosine Genie

Original Task: [blank-project/3lk43b003aq3](https://cosine.sh/p0drixu2k2bx/blank-project/task/3lk43b003aq3)
Author: Janith Manodaya
