### PR TITLE
Migrate Project Configuration from Render to Northflank

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Northflank/Container deployment for FastAPI app
+# Uses Python 3.11 slim base and installs ffmpeg for media processing.
+
+FROM python:3.11-slim
+
+# Ensure Python output is unbuffered and UTF-8
+ENV PYTHONUNBUFFERED=1
+
+# System dependencies
+# - ffmpeg: required for audio/video conversion used by yt-dlp and app flows
+# - build-essential: sometimes needed for building wheels
+# - curl/ca-certificates: for reliable HTTPS requests in some environments
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends ffmpeg build-essential curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency list and install first to leverage Docker layer caching
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir -r /app/requirements.txt
+
+# Copy application source
+COPY . /app
+
+# Create storage directory (can be mapped to a Northflank volume)
+RUN mkdir -p /app/storage
+
+# Expose the service port (Northflank will map this)
+EXPOSE 8080
+
+# Default environment (can be overridden by Northflank Secrets)
+ENV HOST=0.0.0.0 \
+    PORT=8080
+
+# Start the FastAPI app using uvicorn (matches Render Procfile command)
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,35 @@ Packaging with PyInstaller
   The binary will be at dist/greenapi-relay (or .exe on Windows).
   Run it with the same environment variables as above.
 
+Deploying on Render
+- A render.yaml is included for convenience.
+- The service runs with: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+- A persistent disk is mounted at /opt/render/project/src/storage.
+
+Deploying on Northflank (new)
+- This project now includes a Dockerfile for Northflank deployment.
+- Steps:
+  1) Push this repository to GitHub/GitLab/Bitbucket.
+  2) In Northflank, create a Project → Create Service → choose "Combined" (build & deploy from git).
+  3) Under Build options, select "Dockerfile" and set the path to /Dockerfile.
+  4) Under Networking, add a public HTTP port:
+     - Port: 8080
+     - Protocol: HTTP
+     - Public: enabled
+  5) Under Secrets, create a Secret group for environment variables:
+     - GREEN_API_BASE_URL (optional; default https://api.green-api.com)
+     - GREEN_API_INSTANCE_ID (required)
+     - GREEN_API_API_TOKEN (required)
+     - ADMIN_CHAT_ID (required)
+     - ADMIN_PASSWORD (optional)
+     - GEMINI_API_KEY (required for LLM features)
+     - GEMINI_MODEL (optional)
+     - HOST=0.0.0.0
+     - PORT=8080
+  6) (Optional) Volumes: create a persistent volume and mount it at /app/storage to keep SQLite DB and files across deploys.
+  7) Create Service to build & deploy. After build, use the public URL shown in the Northflank dashboard.
+- Health endpoint: GET /health returns {"ok": true, "version": "..."} for container health checks.
+
 Notes and next steps
 - Webhook validation: add signature/origin checks if provided by Green-API
 - QR/status: expose a panel if using Green-API endpoints to fetch QR/status


### PR DESCRIPTION
This pull request modifies the project configuration to enable deployment on Northflank instead of Render.com. Key changes include:

- Added a Dockerfile tailored for Northflank deployment, leveraging Python 3.11 slim image, and installing necessary dependencies like ffmpeg.
- Updated the README.md to include detailed steps for deploying the application on Northflank, highlighting necessary environment variables and networking settings.

This transition maintains the existing render functions while adapting the deployment process to fit Northflank’s requirements.

---

> This pull request was co-created with Cosine Genie

Original Task: [blank-project/ww7zobwgcolf](https://cosine.sh/p0drixu2k2bx/blank-project/task/ww7zobwgcolf)
Author: Janith Manodaya
