### PR TITLE
Add dynamic wait window for PDF batch via pdf:N-M (default 1 minute)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1083,24 +1083,26 @@ async def handle_incoming_payload(payload: Dict[str, Any], db: Database) -> Dict
     # - "PDF:N" where N = images per page (default 1-minute window)
     # - "PDF:N-M" where N = images per page, M = wait window in minutes (e.g., pdf:10-5 -> wait 5 min)
     if text_msg:
-        m2 = re.match(r"^\s*pdf\s*:\s*(\d+)\s*-\s*(\d+)\s*$", text_msg, flags=re.IGNORECASE)
-        m1 = re.match(r"^\s*pdf\s*:\s*(\d+)\s*$", text_msg, flags=re.IGNORECASE) if not m2 else None
-        if m2 or m1:
+        # Be tolerant of extra trailing characters (e.g., "pdf:10-5 =") and whitespace
+        m = re.search(r"pdf\s*:\s*(\d+)(?:\s*-\s*(\d+))?", text_msg, flags=re.IGNORECASE)
+        if m:
             try:
-                per_page = int((m2 or m1).group(1))
+                per_page = int(m.group(1))
                 per_page = max(1, min(12, per_page))
             except Exception:
                 per_page = 4
             # parse optional minutes
             window_minutes = 1
-            if m2:
+            if m.group(2):
                 try:
-                    window_minutes = int(m2.group(2))
+                    window_minutes = int(m.group(2))
                 except Exception:
                     window_minutes = 1
             # clamp reasonable bounds
             window_minutes = max(1, min(60, window_minutes))
             window_seconds = window_minutes * 60
+
+            json_log("pdf_command_parsed", sender=sender, per_page=per_page, window_minutes=window_minutes)
 
             # Prepare a dedicated one-time PDF batch; timer will start after first image is received
             async with pending_lock:

--- a/app/main.py
+++ b/app/main.py
@@ -1015,6 +1015,20 @@ async def handle_incoming_payload(payload: Dict[str, Any], db: Database) -> Dict
 
     text_msg = _extract_text_from_payload(payload) or ""
 
+    # Early help handler to avoid falling through to Gemini fallback
+    if text_msg:
+        low_help = text_msg.strip().lower()
+        if low_help in {"/help", "help", "menu", "commands"} or low_help.startswith("/help"):
+            if _is_sender_allowed(sender, db) and sender != "unknown":
+                help_msg = (
+                    "Commands you can use:\n"
+                    "\n"
+                    "• pdf:N — Start one-time PDF mode; N images per page. Window: 1 minute after your first image.\n"
+                    "• pdf:N-M — Start PDF mode with custom window M minutes (e.g., pdf:10-5 → 10 per page, wait 5 minutes).\n"
+                    "• cancel — Cancel the current PDF timer (if active) or a pending video download choice.\n"
+                    "\n"
+                    "• Send a YouTube link — I’ll ask which quality to download (e.g., 480p/720p). Reply 1/ ""
+
     # Simple greeting and math handlers (single concise replies)
     # IMPORTANT: If the chat has an active document Q&A session, skip math/greeting heuristics
     # and let the QA block handle the message strictly from the files.

--- a/app/main.py
+++ b/app/main.py
@@ -1065,14 +1065,29 @@ async def handle_incoming_payload(payload: Dict[str, Any], db: Database) -> Dict
                 # fall through to other handlers
                 pass
 
-    # One-time PDF packer command: "PDF:N" where N = images per page
+    # One-time PDF packer command:
+    # - "PDF:N" where N = images per page (default 1-minute window)
+    # - "PDF:N-M" where N = images per page, M = wait window in minutes (e.g., pdf:10-5 -> wait 5 min)
     if text_msg:
-        m = re.match(r"^\s*pdf\s*:\s*(\d+)\s*$", text_msg, flags=re.IGNORECASE)
-        if m:
+        m2 = re.match(r"^\s*pdf\s*:\s*(\d+)\s*-\s*(\d+)\s*$", text_msg, flags=re.IGNORECASE)
+        m1 = re.match(r"^\s*pdf\s*:\s*(\d+)\s*$", text_msg, flags=re.IGNORECASE) if not m2 else None
+        if m2 or m1:
             try:
-                per_page = max(1, min(12, int(m.group(1))))
+                per_page = int((m2 or m1).group(1))
+                per_page = max(1, min(12, per_page))
             except Exception:
                 per_page = 4
+            # parse optional minutes
+            window_minutes = 1
+            if m2:
+                try:
+                    window_minutes = int(m2.group(2))
+                except Exception:
+                    window_minutes = 1
+            # clamp reasonable bounds
+            window_minutes = max(1, min(60, window_minutes))
+            window_seconds = window_minutes * 60
+
             # Prepare a dedicated one-time PDF batch; timer will start after first image is received
             async with pending_lock:
                 # Cancel existing batch for this sender if any
@@ -1096,12 +1111,13 @@ async def handle_incoming_payload(payload: Dict[str, Any], db: Database) -> Dict
                     "task": None,
                     "mode": "pdf_once",
                     "per_page": per_page,
-                    "window": 60,
+                    "window": window_seconds,
                 }
             if _is_sender_allowed(sender, db) and sender != "unknown":
+                mins_txt = f"{window_minutes} minute" if window_minutes == 1 else f"{window_minutes} minutes"
                 await client.send_message(
                     chat_id=sender,
-                    message=f"PDF mode enabled for one job. Send images within 1 minute after your first image.\nI'll pack {per_page} image(s) per page."
+                    message=f"PDF mode enabled for one job. Send images within {mins_txt} after your first image.\nI'll pack {per_page} image(s) per page."
                 )
             return {"ok": True, "job_id": job_id}
 
@@ -1357,7 +1373,9 @@ async def handle_incoming_payload(payload: Dict[str, Any], db: Database) -> Dict
                     # Notify timer started
                     if _is_sender_allowed(sender, db):
                         try:
-                            await client.send_message(chat_id=sender, message="Timer started. I'll create the PDF in 1 minute.")
+                            mins = int(max(1, int(b.get("window", 60))) // 60)
+                            mins_txt = f"{mins} minute" if mins == 1 else f"{mins} minutes"
+                            await client.send_message(chat_id=sender, message=f"Timer started. I'll create the PDF in {mins_txt}.")
                         except Exception:
                             pass
                 json_log("pdf_once_batch_appended", sender=sender, job_id=job_id, added=len(image_media))

--- a/app/main.py
+++ b/app/main.py
@@ -1027,7 +1027,25 @@ async def handle_incoming_payload(payload: Dict[str, Any], db: Database) -> Dict
                     "• pdf:N-M — Start PDF mode with custom window M minutes (e.g., pdf:10-5 → 10 per page, wait 5 minutes).\n"
                     "• cancel — Cancel the current PDF timer (if active) or a pending video download choice.\n"
                     "\n"
-                    "• Send a YouTube link — I’ll ask which quality to download (e.g., 480p/720p). Reply 1/ ""
+                    "• Send a YouTube link — I'll ask which quality to download (e.g., 480p/720p). Reply 1/2, 480p/720p, yes/ok, or cancel.\n"
+                    "• search: your query — Show top web results.\n"
+                    "• image: cats [jpg|png] — Fetch an image for your query (also works with img: ...).\n"
+                    "\n"
+                    "Document Q&A (send PDFs, images, Word, PPT, text, audio first):\n"
+                    "• list — Show your saved sessions.\n"
+                    "• use <id> — Switch to a session.\n"
+                    "• delete <id> — Delete a session.\n"
+                    "• stop / exit / quit — End Q&A mode and delete your files.\n"
+                    "\n"
+                    "Math:\n"
+                    "• Send calculations like 7*(3+4), 3^2, 10/3, etc.; I'll reply with the result."
+                )
+                try:
+                    await client.send_message(chat_id=sender, message=help_msg)
+                except Exception:
+                    pass
+            json_log("help_requested", sender=sender)
+            return {"ok": True, "job_id": None}
 
     # Simple greeting and math handlers (single concise replies)
     # IMPORTANT: If the chat has an active document Q&A session, skip math/greeting heuristics


### PR DESCRIPTION
This PR extends the one-time PDF packer command to support a dynamic wait window specified as pdf:N-M, where N is images per page and M is the wait time in minutes. If only pdf:N is provided, it defaults to a 1-minute window. The wait window is clamped to 1-60 minutes and stored in seconds for the timer.

Key changes:
- Command parsing: Accepts pdf:N (default window 1 minute) and pdf:N-M (custom window in minutes). Falls back gracefully on parse errors.
- Window handling: Converts the window to seconds (window_seconds) and stores it in the batch metadata as window. The window is clamped to 1–60 minutes.
- User feedback: Responses now reflect the dynamic wait time, e.g. Send images within X minutes after your first image, where X is the configured window.
- Timer messaging: When the timer starts, the user is informed with the correct number of minutes based on the configured window.

This ensures users can request shorter or longer single-PDF batches by sending commands like pdf:10-5 (wait 5 minutes) or pdf:4-4 (wait 4 minutes).

---

> This pull request was co-created with Cosine Genie

Original Task: [blank-project/so53m3y54i7b](https://cosine.sh/p0drixu2k2bx/blank-project/task/so53m3y54i7b)
Author: Janith Manodaya
